### PR TITLE
Installation document improvement: Install standardiser and statsmodels using conda

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -38,7 +38,7 @@ Follow these steps on Linux/OSX:
 
 6. (optional 24GB) Models are also available when mapping data between orthologues, as in [1]_. N.B The files are 24GB and many models are based solely on orthologue data. To include this functionality, download both `ortho.zip`_ (md5sum: 8f4e4a76f1837613ec4a3dd501d55753) and `ortho.z01`_ (md5sum: 57d6d2a9002f7a8de7ac8e9e4108bf30) to the PIDGINv3 main directory and unzip `ortho.zip`_ (leave all subsequent files compressed)
 
-* N.B Depending on bandwidth, Step 6/7 may take some time
+* N.B Depending on bandwidth, Step 5/6 may take some time
 
 
 Filetree structure

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -24,19 +24,19 @@ Follow these steps on Linux/OSX:
 
 1. ``Download and install Anaconda2 for Python 2.7 from https://www.continuum.io/downloads``
 
-2. Open terminal in Mac/Linux and run ``conda create -c rdkit --name pidgin3_env python=2.7 pip rdkit scikit-learn=0.19.0 pydot graphviz``
+2. Open terminal in Mac/Linux and run ``conda create -c rdkit -c conda-forge --name pidgin3_env python=2.7 rdkit scikit-learn=0.19.0 pydot graphviz standardiser statsmodels``
 
 * N.B. Rdkit may not import on some systems due to a bug. If this happens upgrade to the latest version of conda before creating the above environment using: ``conda update conda``
 
+* N.B. Installs the IMI eTOX `flatkinson standardiser`_ (replaces ChemAxon's standardizer used in previous PIDGIN versions) and statsmodels for p-value correction in predict_enriched.py
+
 3. Now run: ``source activate pidgin3_env`` (This activates the PIDGINv3 virtual environment. N.B This is required for each new terminal session in order to run PIDGIN in the future)
 
-4. Now run: ``pip install standardiser statsmodels`` [Installs the IMI eTOX `flatkinson standardiser`_ (replaces ChemAxon's standardizer used in previous PIDGIN versions) and statsmodels for p-value correction in predict_enriched.py]
+4. Navigate the directory you wish to install PIDGINv3 and in Mac/Linux terminal run ``git clone https://github.com/lhm30/PIDGINv3/`` (recommended) or download/extract the zip from `GitHub`_ webpage (not recommended due to inability to pull updates)
 
-5. Navigate the directory you wish to install PIDGINv3 and in Mac/Linux terminal run ``git clone https://github.com/lhm30/PIDGINv3/`` (recommended) or download/extract the zip from `GitHub`_ webpage (not recommended due to inability to pull updates)
+5. (10GB) Download and unzip `no_ortho.zip`_ (md5sum: af0fd520de846c3cddcaec74dad4241d) into the PIDGINv3 main directory from `https://tinyurl.com/no-ortho`_ (leave all subsequent files compressed)
 
-6. (10GB) Download and unzip `no_ortho.zip`_ (md5sum: af0fd520de846c3cddcaec74dad4241d) into the PIDGINv3 main directory from `https://tinyurl.com/no-ortho`_ (leave all subsequent files compressed)
-
-7. (optional 24GB) Models are also available when mapping data between orthologues, as in [1]_. N.B The files are 24GB and many models are based solely on orthologue data. To include this functionality, download both `ortho.zip`_ (md5sum: 8f4e4a76f1837613ec4a3dd501d55753) and `ortho.z01`_ (md5sum: 57d6d2a9002f7a8de7ac8e9e4108bf30) to the PIDGINv3 main directory and unzip `ortho.zip`_ (leave all subsequent files compressed)
+6. (optional 24GB) Models are also available when mapping data between orthologues, as in [1]_. N.B The files are 24GB and many models are based solely on orthologue data. To include this functionality, download both `ortho.zip`_ (md5sum: 8f4e4a76f1837613ec4a3dd501d55753) and `ortho.z01`_ (md5sum: 57d6d2a9002f7a8de7ac8e9e4108bf30) to the PIDGINv3 main directory and unzip `ortho.zip`_ (leave all subsequent files compressed)
 
 * N.B Depending on bandwidth, Step 6/7 may take some time
 


### PR DESCRIPTION
Install standardiser and statsmodels using conda instead of pip.
* Install standardiser from channel 'conda-forge'.
* Install statsmodels from channel 'anaconda'.
* Remove the 'pip' from dependencies.